### PR TITLE
feat: add ant design ui builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# ui-builder-block-ant
-ui builder for front-end
+# Ant Design UI Builder
+
+A drag-and-drop UI builder inspired by [Blocks](https://github.com/blocks/blocks) that focuses on Ant Design components. The application lets you compose responsive layouts with rows, columns, and forms, tweak component properties, and generate ready-to-use React code.
+
+## Features
+
+- 📦 Component palette with curated Ant Design building blocks (layout, form, inputs, content).
+- 🧱 Nested drag-and-drop canvas with support for rows, columns, forms, and form items.
+- 🧮 Property inspector for editing component settings (layout, labels, placeholders, etc.).
+- 🧾 Live React/Ant Design code generation reflecting the canvas state.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+The development server runs on [http://localhost:5173](http://localhost:5173).
+
+## Build
+
+```bash
+npm run build
+```
+
+This produces an optimized production bundle in the `dist` directory.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ant Design UI Builder</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "ui-builder-block-ant",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "antd": "^5.14.0",
+    "@ant-design/icons": "^5.2.6",
+    "nanoid": "^4.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.4.2",
+    "vite": "^5.1.4"
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,128 @@
+.app-shell {
+  min-height: 100vh;
+}
+
+.app-header {
+  background: #0f172a;
+  display: flex;
+  align-items: center;
+  padding: 0 24px;
+}
+
+.app-header h1 {
+  color: #f8fafc;
+  margin: 0;
+  font-size: 20px;
+}
+
+.app-content {
+  padding: 16px;
+  background: #e2e8f0;
+}
+
+.app-panels {
+  display: grid;
+  grid-template-columns: 280px 1fr 320px;
+  gap: 16px;
+  align-items: stretch;
+  height: 65vh;
+}
+
+.app-panel {
+  background: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-panel-right {
+  overflow-y: auto;
+}
+
+.app-canvas {
+  background: #f8fafc;
+  border-radius: 8px;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+  overflow: auto;
+  padding: 16px;
+}
+
+.builder-canvas {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.builder-node {
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 8px;
+  padding: 12px;
+  position: relative;
+  cursor: grab;
+}
+
+.builder-node-selected {
+  border-color: #1677ff;
+  box-shadow: 0 0 0 2px rgba(22, 119, 255, 0.2);
+}
+
+.builder-node-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+  margin-bottom: 8px;
+}
+
+.builder-node-body {
+  background: rgba(15, 23, 42, 0.02);
+  border-radius: 6px;
+  padding: 12px;
+  min-height: 48px;
+}
+
+.builder-node-container .builder-node-body {
+  min-height: 80px;
+}
+
+.builder-drop-placeholder {
+  border: 1px dashed rgba(15, 23, 42, 0.2);
+  border-radius: 6px;
+  padding: 12px;
+  text-align: center;
+  color: #94a3b8;
+  font-size: 12px;
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.app-code-preview {
+  margin-top: 16px;
+}
+
+@media (max-width: 1200px) {
+  .app-panels {
+    grid-template-columns: 220px 1fr 280px;
+  }
+}
+
+@media (max-width: 960px) {
+  .app-panels {
+    grid-template-columns: 1fr;
+    height: auto;
+  }
+
+  .app-panel-left,
+  .app-panel-right {
+    order: 1;
+  }
+
+  .app-canvas {
+    order: 0;
+    min-height: 320px;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,128 @@
+import { Layout, message } from 'antd';
+import { useMemo, useState } from 'react';
+import './App.css';
+import BuilderCanvas from './components/BuilderCanvas';
+import CodePreview from './components/CodePreview';
+import ComponentInspector from './components/ComponentInspector';
+import ComponentPalette from './components/ComponentPalette';
+import type { BuilderNode, ComponentType } from './state/builderTypes';
+import {
+  addChildNode,
+  canDropOnTarget,
+  createNodeFromType,
+  findNodeById,
+  removeNode,
+  updateNodeProps,
+} from './state/builderUtils';
+
+const { Header, Content } = Layout;
+
+function App() {
+  const [nodes, setNodes] = useState<BuilderNode[]>([]);
+  const [selectedId, setSelectedId] = useState<string | undefined>();
+  const [messageApi, contextHolder] = message.useMessage();
+
+  const selectedNode = useMemo(() => {
+    if (!selectedId) {
+      return undefined;
+    }
+    return findNodeById(nodes, selectedId);
+  }, [nodes, selectedId]);
+
+  const handleDropNew = (targetId: string | null, type: ComponentType) => {
+    setNodes((prev) => {
+      if (!canDropOnTarget(prev, targetId, type)) {
+        messageApi.warning('Drop target does not accept this component.');
+        return prev;
+      }
+      const newNode = createNodeFromType(type);
+      const next = addChildNode(prev, targetId, newNode);
+      setSelectedId(newNode.id);
+      return next;
+    });
+  };
+
+  const handleMoveNode = (nodeId: string, targetId: string | null) => {
+    setNodes((prev) => {
+      if (targetId === nodeId) {
+        return prev;
+      }
+      const targetNode = targetId ? findNodeById(prev, targetId) : undefined;
+      const movingNode = findNodeById(prev, nodeId);
+      if (!movingNode) {
+        return prev;
+      }
+      const dropType = movingNode.type;
+      if (!canDropOnTarget(prev, targetId, dropType)) {
+        messageApi.warning('Cannot move component to the selected area.');
+        return prev;
+      }
+      const { nodes: withoutNode, removed } = removeNode(prev, nodeId);
+      if (!removed) {
+        return prev;
+      }
+      if (targetNode && targetNode.children?.some((child) => child.id === nodeId)) {
+        return prev;
+      }
+      const sanitizedNode: BuilderNode = {
+        ...removed,
+        children: removed.children ? [...removed.children] : undefined,
+      };
+      const next = addChildNode(withoutNode, targetId, sanitizedNode);
+      setSelectedId(nodeId);
+      return next;
+    });
+  };
+
+  const handleUpdateNode = (id: string, patch: Record<string, any>) => {
+    setNodes((prev) =>
+      updateNodeProps(prev, id, (node) => ({
+        ...node,
+        props: { ...node.props, ...patch },
+      }))
+    );
+  };
+
+  const handleRemoveNode = (id: string) => {
+    setNodes((prev) => {
+      const { nodes: next } = removeNode(prev, id);
+      if (selectedId === id) {
+        setSelectedId(undefined);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <Layout className="app-shell">
+      {contextHolder}
+      <Header className="app-header">
+        <h1>Ant Design UI Builder</h1>
+      </Header>
+      <Content className="app-content">
+        <div className="app-panels">
+          <aside className="app-panel app-panel-left">
+            <ComponentPalette onStartDrag={(_type) => messageApi.destroy()} />
+          </aside>
+          <main className="app-canvas">
+            <BuilderCanvas
+              nodes={nodes}
+              selectedId={selectedId}
+              onSelect={setSelectedId}
+              onDropNew={handleDropNew}
+              onMoveNode={handleMoveNode}
+            />
+          </main>
+          <aside className="app-panel app-panel-right">
+            <ComponentInspector node={selectedNode} onUpdate={handleUpdateNode} onRemove={handleRemoveNode} />
+          </aside>
+        </div>
+        <div className="app-code-preview">
+          <CodePreview nodes={nodes} />
+        </div>
+      </Content>
+    </Layout>
+  );
+}
+
+export default App;

--- a/src/components/BuilderCanvas.tsx
+++ b/src/components/BuilderCanvas.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import {
+  Button,
+  Checkbox,
+  Col,
+  DatePicker,
+  Empty,
+  Form,
+  Input,
+  Row,
+  Select,
+  Typography,
+} from 'antd';
+import type { BuilderNode, ComponentType } from '../state/builderTypes';
+import { canDropOnTarget, isDescendant } from '../state/builderUtils';
+import { componentRegistry } from '../state/componentRegistry';
+
+const { Paragraph } = Typography;
+
+interface BuilderCanvasProps {
+  nodes: BuilderNode[];
+  selectedId?: string;
+  onSelect: (id: string) => void;
+  onDropNew: (targetId: string | null, type: ComponentType) => void;
+  onMoveNode: (nodeId: string, targetId: string | null) => void;
+}
+
+const dropDataMime = 'application/x-builder';
+
+const BuilderCanvas: React.FC<BuilderCanvasProps> = ({
+  nodes,
+  selectedId,
+  onSelect,
+  onDropNew,
+  onMoveNode,
+}) => {
+  const handleDragOver = (event: React.DragEvent, targetId: string | null) => {
+    const raw = event.dataTransfer.getData(dropDataMime);
+    if (!raw) {
+      return;
+    }
+    try {
+      const payload = JSON.parse(raw) as { mode: string; type: ComponentType; nodeId?: string };
+      if (!canDropOnTarget(nodes, targetId, payload.type)) {
+        event.dataTransfer.dropEffect = 'none';
+        return;
+      }
+      if (payload.mode === 'move' && payload.nodeId && targetId && isDescendant(nodes, payload.nodeId, targetId)) {
+        event.dataTransfer.dropEffect = 'none';
+        return;
+      }
+      event.preventDefault();
+      event.dataTransfer.dropEffect = payload.mode === 'new' ? 'copy' : 'move';
+    } catch (error) {
+      // ignore
+    }
+  };
+
+  const handleDrop = (event: React.DragEvent, targetId: string | null) => {
+    const raw = event.dataTransfer.getData(dropDataMime);
+    if (!raw) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    try {
+      const payload = JSON.parse(raw) as { mode: string; type: ComponentType; nodeId?: string };
+      if (!canDropOnTarget(nodes, targetId, payload.type)) {
+        return;
+      }
+      if (payload.mode === 'new') {
+        onDropNew(targetId, payload.type);
+      } else if (payload.mode === 'move' && payload.nodeId) {
+        if (targetId && isDescendant(nodes, payload.nodeId, targetId)) {
+          return;
+        }
+        onMoveNode(payload.nodeId, targetId);
+      }
+    } catch (error) {
+      // ignore malformed data
+    }
+  };
+
+  const renderChildren = (children: BuilderNode[] | undefined) => {
+    if (!children || children.length === 0) {
+      return (
+        <div className="builder-drop-placeholder" data-placeholder>
+          Drop components here
+        </div>
+      );
+    }
+    return children.map((child) => renderNode(child));
+  };
+
+  const renderContent = (node: BuilderNode, children: React.ReactNode) => {
+    switch (node.type) {
+      case 'Row':
+        return (
+          <Row gutter={node.props.gutter} justify={node.props.justify} align={node.props.align}>
+            {children}
+          </Row>
+        );
+      case 'Col':
+        return (
+          <Col span={node.props.span} flex={node.props.flex}>
+            {children}
+          </Col>
+        );
+      case 'Form':
+        return (
+          <Form layout={node.props.layout} colon={node.props.colon} disabled>
+            {children}
+          </Form>
+        );
+      case 'FormItem':
+        return (
+          <Form.Item label={node.props.label} name={node.props.name} required={node.props.required}>
+            {children}
+          </Form.Item>
+        );
+      case 'Button':
+        return (
+          <Button type={node.props.type} block={node.props.block} disabled>
+            {node.props.text}
+          </Button>
+        );
+      case 'Input':
+        return <Input placeholder={node.props.placeholder} allowClear={node.props.allowClear} readOnly />;
+      case 'Select':
+        return (
+          <Select
+            placeholder={node.props.placeholder}
+            options={node.props.options}
+            style={{ width: '100%' }}
+            disabled
+          />
+        );
+      case 'Checkbox':
+        return (
+          <Checkbox checked={node.props.checked} disabled>
+            {node.props.text}
+          </Checkbox>
+        );
+      case 'DatePicker':
+        return <DatePicker picker={node.props.picker} style={{ width: '100%' }} disabled />;
+      case 'Paragraph':
+        return <Paragraph>{node.props.text}</Paragraph>;
+      default:
+        return <div>{children}</div>;
+    }
+  };
+
+  const renderNode = (node: BuilderNode) => {
+    const config = componentRegistry[node.type];
+    const isSelected = selectedId === node.id;
+    const className = ['builder-node', isSelected ? 'builder-node-selected' : '', config.supportsChildren ? 'builder-node-container' : '']
+      .filter(Boolean)
+      .join(' ');
+
+    const handleNodeDragStart = (event: React.DragEvent) => {
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData(
+        dropDataMime,
+        JSON.stringify({ mode: 'move', nodeId: node.id, type: node.type })
+      );
+    };
+
+    const droppableProps = config.supportsChildren
+      ? {
+          onDragOver: (event: React.DragEvent) => handleDragOver(event, node.id),
+          onDrop: (event: React.DragEvent) => handleDrop(event, node.id),
+        }
+      : undefined;
+
+    return (
+      <div
+        key={node.id}
+        className={className}
+        draggable
+        onDragStart={handleNodeDragStart}
+        onClick={(event) => {
+          event.stopPropagation();
+          onSelect(node.id);
+        }}
+      >
+        <div className="builder-node-label">{config.label}</div>
+        <div className="builder-node-body" {...droppableProps}>
+          {renderContent(node, renderChildren(node.children))}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className="builder-canvas"
+      onDragOver={(event) => handleDragOver(event, null)}
+      onDrop={(event) => handleDrop(event, null)}
+    >
+      {nodes.length === 0 ? (
+        <Empty description="Drag components here" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+      ) : (
+        nodes.map((node) => renderNode(node))
+      )}
+    </div>
+  );
+};
+
+export default BuilderCanvas;

--- a/src/components/CodePreview.tsx
+++ b/src/components/CodePreview.tsx
@@ -1,0 +1,138 @@
+import { Card } from 'antd';
+import { useMemo } from 'react';
+import type { BuilderNode } from '../state/builderTypes';
+
+const indent = (depth: number) => '  '.repeat(depth);
+
+const formatValue = (value: unknown, depth: number) => {
+  if (typeof value === 'string') {
+    return `"${value}"`;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return `{${value}}`;
+  }
+  if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
+    const json = JSON.stringify(value, null, 2)
+      .split('\n')
+      .map((line, index) => (index === 0 ? line : `${indent(depth + 2)}${line}`))
+      .join('\n');
+    return `{${json}}`;
+  }
+  return '{undefined}';
+};
+
+const getComponentName = (node: BuilderNode): string => {
+  switch (node.type) {
+    case 'FormItem':
+      return 'Form.Item';
+    case 'Paragraph':
+      return 'Paragraph';
+    default:
+      return node.type;
+  }
+};
+
+const prepareProps = (node: BuilderNode, depth: number): string => {
+  const props = { ...node.props };
+  if (node.type === 'Button' || node.type === 'Checkbox' || node.type === 'Paragraph') {
+    delete (props as any).text;
+  }
+  if (node.type === 'Select') {
+    // ensure options are preserved as array
+    props.options = props.options ?? [];
+  }
+  const entries = Object.entries(props).filter(([, value]) => value !== undefined && value !== '');
+  if (entries.length === 0) {
+    return '';
+  }
+  return entries
+    .map(([key, value]) => ` ${key}=${formatValue(value, depth)}`)
+    .join('');
+};
+
+const renderNode = (node: BuilderNode, depth: number): string => {
+  const componentName = getComponentName(node);
+  const propsString = prepareProps(node, depth);
+  const children = node.children ?? [];
+  switch (node.type) {
+    case 'Button': {
+      const text = node.props.text ?? 'Button';
+      return `${indent(depth)}<${componentName}${propsString}>${text}</${componentName}>`;
+    }
+    case 'Checkbox': {
+      const text = node.props.text ?? 'Checkbox';
+      return `${indent(depth)}<${componentName}${propsString}>${text}</${componentName}>`;
+    }
+    case 'Paragraph': {
+      const text = node.props.text ?? '';
+      return `${indent(depth)}<${componentName}${propsString}>${text}</${componentName}>`;
+    }
+    case 'Input':
+    case 'Select':
+    case 'DatePicker': {
+      return `${indent(depth)}<${componentName}${propsString} />`;
+    }
+    default: {
+      const childContent = children.map((child) => renderNode(child, depth + 1)).join('\n');
+      if (childContent) {
+        return `${indent(depth)}<${componentName}${propsString}>
+${childContent}
+${indent(depth)}</${componentName}>`;
+      }
+      return `${indent(depth)}<${componentName}${propsString} />`;
+    }
+  }
+};
+
+const renderTree = (nodes: BuilderNode[]): string => {
+  if (nodes.length === 0) {
+    return '      {/* Drag components into the canvas */}';
+  }
+  return nodes.map((node) => renderNode(node, 3)).join('\n');
+};
+
+const generateCode = (nodes: BuilderNode[]): string => {
+  return `import React from 'react';
+import { Row, Col, Form, Button, Input, Select, Checkbox, DatePicker, Typography } from 'antd';
+
+const { Paragraph } = Typography;
+
+const GeneratedLayout: React.FC = () => {
+  return (
+    <>
+${renderTree(nodes)}
+    </>
+  );
+};
+
+export default GeneratedLayout;
+`;
+};
+
+interface CodePreviewProps {
+  nodes: BuilderNode[];
+}
+
+const CodePreview: React.FC<CodePreviewProps> = ({ nodes }) => {
+  const code = useMemo(() => generateCode(nodes), [nodes]);
+  return (
+    <Card title="Generated Code" size="small" bodyStyle={{ padding: 0 }}>
+      <pre
+        style={{
+          margin: 0,
+          padding: 16,
+          background: '#0f172a',
+          color: '#e2e8f0',
+          minHeight: 240,
+          overflowX: 'auto',
+          fontFamily: 'Menlo, Monaco, Consolas, "Courier New", monospace',
+          fontSize: 12,
+        }}
+      >
+        {code}
+      </pre>
+    </Card>
+  );
+};
+
+export default CodePreview;

--- a/src/components/ComponentInspector.tsx
+++ b/src/components/ComponentInspector.tsx
@@ -1,0 +1,306 @@
+import {
+  Button as AntButton,
+  Divider,
+  Form,
+  Input,
+  InputNumber,
+  Select,
+  Space,
+  Switch,
+  Typography,
+} from 'antd';
+import type { BuilderNode } from '../state/builderTypes';
+
+const { Title, Text } = Typography;
+const { TextArea } = Input;
+
+interface ComponentInspectorProps {
+  node?: BuilderNode;
+  onUpdate: (id: string, patch: Record<string, any>) => void;
+  onRemove: (id: string) => void;
+}
+
+const ComponentInspector: React.FC<ComponentInspectorProps> = ({ node, onUpdate, onRemove }) => {
+  const handlePropChange = (key: string, value: any) => {
+    if (!node) {
+      return;
+    }
+    onUpdate(node.id, { [key]: value });
+  };
+
+  if (!node) {
+    return (
+      <div style={{ padding: 16 }}>
+        <Title level={4} style={{ marginBottom: 8 }}>
+          Inspector
+        </Title>
+        <Text type="secondary">Select a component to edit its properties.</Text>
+      </div>
+    );
+  }
+
+  const renderRowControls = () => (
+    <>
+      <Form.Item label="Gutter">
+        <InputNumber
+          min={0}
+          value={node.props.gutter}
+          onChange={(value) => handlePropChange('gutter', value ?? 0)}
+          style={{ width: '100%' }}
+        />
+      </Form.Item>
+      <Form.Item label="Justify">
+        <Select
+          value={node.props.justify}
+          onChange={(value) => handlePropChange('justify', value)}
+          options={['start', 'center', 'end', 'space-between', 'space-around'].map((option) => ({
+            label: option,
+            value: option,
+          }))}
+        />
+      </Form.Item>
+      <Form.Item label="Align">
+        <Select
+          value={node.props.align}
+          onChange={(value) => handlePropChange('align', value)}
+          options={['top', 'middle', 'bottom', 'stretch'].map((option) => ({
+            label: option,
+            value: option,
+          }))}
+        />
+      </Form.Item>
+    </>
+  );
+
+  const renderColControls = () => (
+    <>
+      <Form.Item label="Span">
+        <InputNumber
+          min={1}
+          max={24}
+          value={node.props.span}
+          onChange={(value) => handlePropChange('span', value ?? 1)}
+          style={{ width: '100%' }}
+        />
+      </Form.Item>
+      <Form.Item label="Flex">
+        <Input
+          value={node.props.flex ?? ''}
+          onChange={(event) => handlePropChange('flex', event.target.value || undefined)}
+          placeholder="e.g. 1 1 200px"
+        />
+      </Form.Item>
+    </>
+  );
+
+  const renderFormControls = () => (
+    <>
+      <Form.Item label="Layout">
+        <Select
+          value={node.props.layout}
+          onChange={(value) => handlePropChange('layout', value)}
+          options={['horizontal', 'vertical', 'inline'].map((layout) => ({ label: layout, value: layout }))}
+        />
+      </Form.Item>
+      <Form.Item label="Show Colon">
+        <Switch
+          checked={node.props.colon}
+          onChange={(value) => handlePropChange('colon', value)}
+        />
+      </Form.Item>
+    </>
+  );
+
+  const renderFormItemControls = () => (
+    <>
+      <Form.Item label="Label">
+        <Input
+          value={node.props.label}
+          onChange={(event) => handlePropChange('label', event.target.value)}
+        />
+      </Form.Item>
+      <Form.Item label="Field Name">
+        <Input
+          value={node.props.name}
+          onChange={(event) => handlePropChange('name', event.target.value)}
+        />
+      </Form.Item>
+      <Form.Item label="Required">
+        <Switch
+          checked={node.props.required}
+          onChange={(value) => handlePropChange('required', value)}
+        />
+      </Form.Item>
+    </>
+  );
+
+  const renderButtonControls = () => (
+    <>
+      <Form.Item label="Label">
+        <Input
+          value={node.props.text}
+          onChange={(event) => handlePropChange('text', event.target.value)}
+        />
+      </Form.Item>
+      <Form.Item label="Type">
+        <Select
+          value={node.props.type}
+          onChange={(value) => handlePropChange('type', value)}
+          options={['default', 'primary', 'dashed', 'link', 'text'].map((type) => ({ label: type, value: type }))}
+        />
+      </Form.Item>
+      <Form.Item label="Block">
+        <Switch
+          checked={Boolean(node.props.block)}
+          onChange={(value) => handlePropChange('block', value)}
+        />
+      </Form.Item>
+    </>
+  );
+
+  const renderInputControls = () => (
+    <>
+      <Form.Item label="Placeholder">
+        <Input
+          value={node.props.placeholder}
+          onChange={(event) => handlePropChange('placeholder', event.target.value)}
+        />
+      </Form.Item>
+      <Form.Item label="Allow Clear">
+        <Switch
+          checked={Boolean(node.props.allowClear)}
+          onChange={(value) => handlePropChange('allowClear', value)}
+        />
+      </Form.Item>
+    </>
+  );
+
+  const renderSelectControls = () => {
+    const optionText = (node.props.options ?? [])
+      .map((option: { label: string; value: string }) => `${option.label}:${option.value}`)
+      .join('\n');
+    return (
+      <>
+        <Form.Item label="Placeholder">
+          <Input
+            value={node.props.placeholder}
+            onChange={(event) => handlePropChange('placeholder', event.target.value)}
+          />
+        </Form.Item>
+        <Form.Item label="Options (label:value per line)">
+          <TextArea
+            rows={4}
+            value={optionText}
+            onChange={(event) => {
+              const value = event.target.value;
+              const options = value
+                .split('\n')
+                .map((line) => line.trim())
+                .filter(Boolean)
+                .map((line) => {
+                  const [label, val] = line.split(':');
+                  const trimmedLabel = label?.trim() ?? '';
+                  const trimmedValue = (val ?? label)?.trim() ?? '';
+                  return { label: trimmedLabel, value: trimmedValue };
+                });
+              handlePropChange('options', options);
+            }}
+          />
+        </Form.Item>
+      </>
+    );
+  };
+
+  const renderCheckboxControls = () => (
+    <>
+      <Form.Item label="Label">
+        <Input
+          value={node.props.text}
+          onChange={(event) => handlePropChange('text', event.target.value)}
+        />
+      </Form.Item>
+      <Form.Item label="Checked">
+        <Switch
+          checked={Boolean(node.props.checked)}
+          onChange={(value) => handlePropChange('checked', value)}
+        />
+      </Form.Item>
+    </>
+  );
+
+  const renderDatePickerControls = () => (
+    <>
+      <Form.Item label="Picker Type">
+        <Select
+          value={node.props.picker}
+          onChange={(value) => handlePropChange('picker', value)}
+          options={['date', 'week', 'month', 'quarter', 'year'].map((picker) => ({
+            label: picker,
+            value: picker,
+          }))}
+        />
+      </Form.Item>
+    </>
+  );
+
+  const renderParagraphControls = () => (
+    <>
+      <Form.Item label="Text">
+        <TextArea
+          rows={3}
+          value={node.props.text}
+          onChange={(event) => handlePropChange('text', event.target.value)}
+        />
+      </Form.Item>
+    </>
+  );
+
+  const renderFormForNode = () => {
+    switch (node.type) {
+      case 'Row':
+        return renderRowControls();
+      case 'Col':
+        return renderColControls();
+      case 'Form':
+        return renderFormControls();
+      case 'FormItem':
+        return renderFormItemControls();
+      case 'Button':
+        return renderButtonControls();
+      case 'Input':
+        return renderInputControls();
+      case 'Select':
+        return renderSelectControls();
+      case 'Checkbox':
+        return renderCheckboxControls();
+      case 'DatePicker':
+        return renderDatePickerControls();
+      case 'Paragraph':
+        return renderParagraphControls();
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div style={{ padding: 16, height: '100%', overflowY: 'auto' }}>
+      <Space direction="vertical" style={{ width: '100%' }} size="large">
+        <div>
+          <Title level={4} style={{ marginBottom: 0 }}>
+            {node.type}
+          </Title>
+          <Text type="secondary">Adjust component properties</Text>
+        </div>
+        <Form layout="vertical" colon={false} requiredMark={false} style={{ width: '100%' }}>
+          {renderFormForNode()}
+        </Form>
+        <Divider style={{ margin: '8px 0' }} />
+        <AntButton danger onClick={() => onRemove(node.id)}>
+          Remove Component
+        </AntButton>
+      </Space>
+    </div>
+  );
+};
+
+export default ComponentInspector;

--- a/src/components/ComponentPalette.tsx
+++ b/src/components/ComponentPalette.tsx
@@ -1,0 +1,49 @@
+import { Card, Divider, Typography } from 'antd';
+import { componentList } from '../state/componentRegistry';
+import type { ComponentType } from '../state/builderTypes';
+
+const { Title, Paragraph } = Typography;
+
+interface ComponentPaletteProps {
+  onStartDrag: (type: ComponentType) => void;
+}
+
+const ComponentPalette: React.FC<ComponentPaletteProps> = ({ onStartDrag }) => {
+  return (
+    <div style={{ padding: 16 }}>
+      <Title level={4} style={{ marginBottom: 8 }}>
+        Components
+      </Title>
+      <Paragraph type="secondary" style={{ marginBottom: 16 }}>
+        Drag components into the canvas to build your layout.
+      </Paragraph>
+      <Divider style={{ margin: '12px 0' }} />
+      <div style={{ display: 'grid', gap: 12 }}>
+        {componentList.map((config) => (
+          <Card
+            key={config.type}
+            size="small"
+            hoverable
+            style={{ cursor: 'grab' }}
+            draggable
+            onDragStart={(event) => {
+              event.dataTransfer.effectAllowed = 'copy';
+              event.dataTransfer.setData(
+                'application/x-builder',
+                JSON.stringify({ mode: 'new', type: config.type })
+              );
+              onStartDrag(config.type);
+            }}
+          >
+            <Card.Meta
+              title={config.label}
+              description={config.description ?? `${config.type} component`}
+            />
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ComponentPalette;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,16 @@
+:root {
+  font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
+  color: #1f2933;
+  background-color: #f3f4f6;
+}
+
+body,
+html,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background-color: #f5f5f5;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import 'antd/dist/reset.css';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/state/builderTypes.ts
+++ b/src/state/builderTypes.ts
@@ -1,0 +1,29 @@
+export type ComponentType =
+  | 'Row'
+  | 'Col'
+  | 'Form'
+  | 'FormItem'
+  | 'Button'
+  | 'Input'
+  | 'Select'
+  | 'Checkbox'
+  | 'DatePicker'
+  | 'Paragraph';
+
+export interface BuilderNode {
+  id: string;
+  type: ComponentType;
+  props: Record<string, any>;
+  children?: BuilderNode[];
+}
+
+export interface ComponentConfig {
+  type: ComponentType;
+  label: string;
+  icon?: string;
+  description?: string;
+  defaultProps: Record<string, any>;
+  supportsChildren: boolean;
+  allowedChildren?: ComponentType[];
+  createChildren?: () => BuilderNode[];
+}

--- a/src/state/builderUtils.ts
+++ b/src/state/builderUtils.ts
@@ -1,0 +1,130 @@
+import { BuilderNode, ComponentType } from './builderTypes';
+import { canAcceptChild, componentRegistry, createDefaultNode } from './componentRegistry';
+
+export const findNodeById = (nodes: BuilderNode[], id: string): BuilderNode | undefined => {
+  for (const node of nodes) {
+    if (node.id === id) {
+      return node;
+    }
+    if (node.children) {
+      const child = findNodeById(node.children, id);
+      if (child) {
+        return child;
+      }
+    }
+  }
+  return undefined;
+};
+
+export const updateNodeProps = (
+  nodes: BuilderNode[],
+  id: string,
+  updater: (prev: BuilderNode) => BuilderNode
+): BuilderNode[] => {
+  return nodes.map((node) => {
+    if (node.id === id) {
+      return updater(node);
+    }
+    if (node.children) {
+      return {
+        ...node,
+        children: updateNodeProps(node.children, id, updater),
+      };
+    }
+    return node;
+  });
+};
+
+export const removeNode = (
+  nodes: BuilderNode[],
+  id: string
+): { nodes: BuilderNode[]; removed?: BuilderNode } => {
+  const next: BuilderNode[] = [];
+  let removed: BuilderNode | undefined;
+  for (const node of nodes) {
+    if (node.id === id) {
+      removed = node;
+      continue;
+    }
+    if (node.children) {
+      const result = removeNode(node.children, id);
+      if (result.removed) {
+        removed = result.removed;
+      }
+      next.push({
+        ...node,
+        children: result.nodes,
+      });
+    } else {
+      next.push(node);
+    }
+  }
+  return { nodes: next, removed };
+};
+
+export const addChildNode = (
+  nodes: BuilderNode[],
+  targetId: string | null,
+  newNode: BuilderNode
+): BuilderNode[] => {
+  if (targetId === null) {
+    return [...nodes, newNode];
+  }
+  return nodes.map((node) => {
+    if (node.id === targetId) {
+      const children = node.children ? [...node.children, newNode] : [newNode];
+      return { ...node, children };
+    }
+    if (node.children) {
+      return { ...node, children: addChildNode(node.children, targetId, newNode) };
+    }
+    return node;
+  });
+};
+
+export const createNodeFromType = (type: ComponentType): BuilderNode => {
+  return createDefaultNode(type);
+};
+
+export const canDropOnTarget = (
+  nodes: BuilderNode[],
+  targetId: string | null,
+  childType: ComponentType
+): boolean => {
+  if (targetId === null) {
+    return true;
+  }
+  const target = findNodeById(nodes, targetId);
+  if (!target) {
+    return false;
+  }
+  return canAcceptChild(target.type, childType);
+};
+
+export const ensureChildArray = (node: BuilderNode): BuilderNode => {
+  if (!componentRegistry[node.type].supportsChildren) {
+    return node;
+  }
+  return {
+    ...node,
+    children: node.children ? [...node.children] : [],
+  };
+};
+
+export const isDescendant = (nodes: BuilderNode[], parentId: string, possibleChildId: string): boolean => {
+  const parent = findNodeById(nodes, parentId);
+  if (!parent || !parent.children) {
+    return false;
+  }
+  const stack = [...parent.children];
+  while (stack.length) {
+    const node = stack.pop()!;
+    if (node.id === possibleChildId) {
+      return true;
+    }
+    if (node.children) {
+      stack.push(...node.children);
+    }
+  }
+  return false;
+};

--- a/src/state/componentRegistry.ts
+++ b/src/state/componentRegistry.ts
@@ -1,0 +1,157 @@
+import { nanoid } from 'nanoid';
+import { BuilderNode, ComponentConfig, ComponentType } from './builderTypes';
+
+const createNode = (
+  type: ComponentType,
+  props: Record<string, any>,
+  children?: BuilderNode[]
+): BuilderNode => ({
+  id: nanoid(),
+  type,
+  props,
+  children,
+});
+
+export const componentRegistry: Record<ComponentType, ComponentConfig> = {
+  Row: {
+    type: 'Row',
+    label: 'Row',
+    defaultProps: {
+      gutter: 16,
+      justify: 'start',
+      align: 'top',
+    },
+    supportsChildren: true,
+    allowedChildren: ['Col'],
+    createChildren: () => [
+      createNode('Col', { span: 12 }, []),
+      createNode('Col', { span: 12 }, []),
+    ],
+  },
+  Col: {
+    type: 'Col',
+    label: 'Column',
+    defaultProps: {
+      span: 12,
+      flex: undefined,
+    },
+    supportsChildren: true,
+    allowedChildren: [
+      'Row',
+      'Form',
+      'FormItem',
+      'Button',
+      'Input',
+      'Select',
+      'Checkbox',
+      'DatePicker',
+      'Paragraph',
+    ],
+  },
+  Form: {
+    type: 'Form',
+    label: 'Form',
+    defaultProps: {
+      layout: 'vertical',
+      colon: false,
+    },
+    supportsChildren: true,
+    allowedChildren: ['FormItem', 'Row', 'Col', 'Button', 'Paragraph'],
+    createChildren: () => [
+      createNode('FormItem', { label: 'Field Label' }, [
+        createNode('Input', { placeholder: 'Enter value' }),
+      ]),
+    ],
+  },
+  FormItem: {
+    type: 'FormItem',
+    label: 'Form Item',
+    defaultProps: {
+      label: 'Field Label',
+      name: 'fieldName',
+      required: false,
+    },
+    supportsChildren: true,
+    allowedChildren: ['Input', 'Select', 'Checkbox', 'DatePicker', 'Paragraph', 'Button'],
+  },
+  Button: {
+    type: 'Button',
+    label: 'Button',
+    defaultProps: {
+      text: 'Submit',
+      type: 'primary',
+      block: false,
+    },
+    supportsChildren: false,
+  },
+  Input: {
+    type: 'Input',
+    label: 'Input',
+    defaultProps: {
+      placeholder: 'Input',
+      allowClear: true,
+    },
+    supportsChildren: false,
+  },
+  Select: {
+    type: 'Select',
+    label: 'Select',
+    defaultProps: {
+      placeholder: 'Select option',
+      options: [
+        { label: 'Option A', value: 'a' },
+        { label: 'Option B', value: 'b' },
+      ],
+    },
+    supportsChildren: false,
+  },
+  Checkbox: {
+    type: 'Checkbox',
+    label: 'Checkbox',
+    defaultProps: {
+      text: 'Accept terms',
+      checked: false,
+    },
+    supportsChildren: false,
+  },
+  DatePicker: {
+    type: 'DatePicker',
+    label: 'Date Picker',
+    defaultProps: {
+      picker: 'date',
+    },
+    supportsChildren: false,
+  },
+  Paragraph: {
+    type: 'Paragraph',
+    label: 'Paragraph',
+    defaultProps: {
+      text: 'Descriptive text goes here.',
+    },
+    supportsChildren: false,
+  },
+};
+
+export const componentList: ComponentConfig[] = Object.values(componentRegistry);
+
+export const createDefaultNode = (type: ComponentType): BuilderNode => {
+  const config = componentRegistry[type];
+  const children = config.createChildren ? config.createChildren() : config.supportsChildren ? [] : undefined;
+  return {
+    id: nanoid(),
+    type,
+    props: { ...config.defaultProps },
+    children,
+  };
+};
+
+export const canAcceptChild = (parentType: ComponentType, childType: ComponentType): boolean => {
+  const parent = componentRegistry[parentType];
+  if (!parent || !parent.supportsChildren) {
+    return false;
+  }
+  if (!parent.allowedChildren || parent.allowedChildren.length === 0) {
+    return true;
+  }
+  return parent.allowedChildren.includes(childType);
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React workspace for the Ant Design powered UI builder
- implement drag-and-drop canvas, component palette, property inspector, and live code preview
- add builder state utilities and component registry to manage nested layouts and generated defaults

## Testing
- npm install *(fails in sandbox: registry access returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d024e4b46c83289e9e83f3a98503da