### PR TITLE
Support reordering dropped components

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -73,6 +73,24 @@
   padding: 12px;
 }
 
+.builder-node-container[data-node-type='Col'] {
+  display: inline-block;
+  width: auto;
+  min-width: 0;
+  padding: 8px;
+  background: rgba(15, 23, 42, 0.02);
+}
+
+.builder-node-container[data-node-type='Col'] .builder-node-label {
+  margin-bottom: 4px;
+}
+
+.builder-node-container[data-node-type='Col'] .builder-node-body {
+  padding: 0;
+  background: transparent;
+  min-height: 40px;
+}
+
 .builder-node-container .builder-node-label {
   font-size: 12px;
   font-weight: 600;
@@ -138,6 +156,37 @@
   color: #94a3b8;
   font-size: 12px;
   background: rgba(148, 163, 184, 0.12);
+}
+
+.builder-drop-placeholder-active {
+  border-color: rgba(22, 119, 255, 0.4);
+  background: rgba(22, 119, 255, 0.08);
+  color: #1677ff;
+}
+
+.builder-drop-zone {
+  width: 100%;
+  height: 10px;
+  margin: 4px 0;
+  border-radius: 4px;
+  border: 1px dashed transparent;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.builder-drop-zone-active {
+  border-color: rgba(22, 119, 255, 0.4);
+  background: rgba(22, 119, 255, 0.12);
+}
+
+.builder-empty-root {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+}
+
+.builder-empty-root .builder-drop-zone {
+  max-width: 360px;
 }
 
 .app-code-preview {


### PR DESCRIPTION
## Summary
- allow inserting and moving nodes at explicit indices by tracking node locations and inserting at a requested position
- add builder canvas drop zone logic so existing components can be dragged between placeholders with visual feedback
- tweak column styling so inline components display in their natural Ant Design layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d02eaa022c83288bd91e65bb869221