### PR TITLE
Allow moving nodes within same parent

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,6 @@ function App() {
       if (targetId === nodeId) {
         return prev;
       }
-      const targetNode = targetId ? findNodeById(prev, targetId) : undefined;
       const movingNode = findNodeById(prev, nodeId);
       if (!movingNode) {
         return prev;
@@ -61,9 +60,6 @@ function App() {
       const sourceLocation = findNodeLocation(prev, nodeId);
       const { nodes: withoutNode, removed } = removeNode(prev, nodeId);
       if (!removed) {
-        return prev;
-      }
-      if (targetNode && targetNode.children?.some((child) => child.id === nodeId)) {
         return prev;
       }
       let nextIndex = index;


### PR DESCRIPTION
## Summary
- allow existing canvas nodes to be repositioned within the same parent
- keep selection in sync after moves by reusing existing logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0339462c4832882c960d04b95397f